### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "husky": "^9.1.7",
     "knip": "^6.14.1",
     "lint-staged": "^17.0.5",
-    "npm-check-updates": "^22.1.0",
+    "npm-check-updates": "^22.2.0",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## 📦 Dependency Updates

This branch was regenerated only after the read-only dependency refresh job completed successfully and produced validated package changes.

Refresh mode: `validated-refresh`.
Change kind: `manifest-only`.

<details>
<summary>Direct package.json updates</summary>

```json
{
  "npm-check-updates": "^22.2.0"
}
```
</details>

<details>
<summary>Lockfile convergence hotspots (advisory)</summary>

| Package | Versions | Entries |
| --- | --- | --- |
| `@radix-ui/react-slot` | `1.2.3` (5), `1.2.4` (1) | 6 |
| `@radix-ui/react-primitive` | `2.1.3` (1), `2.1.4` (4) | 5 |
| `ansi-styles` | `4.3.0` (1), `6.2.3` (4) | 5 |
| `@radix-ui/react-context` | `1.1.2` (1), `1.1.3` (2) | 3 |
| `eslint-visitor-keys` | `3.4.3` (1), `5.0.1` (1) | 2 |
| `ignore` | `5.3.2` (1), `7.0.5` (1) | 2 |
| `postcss` | `8.4.31` (1), `8.5.14` (1) | 2 |
| `slice-ansi` | `7.1.2` (1), `8.0.0` (1) | 2 |
| `string-width` | `7.2.0` (1), `8.2.1` (1) | 2 |
| `wrap-ansi` | `10.0.0` (1), `9.0.2` (1) | 2 |

No automatic dedupe or override changes were applied beyond the validated refresh artifact.
</details>
